### PR TITLE
Add command to copy channel entries + customers/products config

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "listr": "^0.14.3",
     "loader-utils": "^1.1.0",
     "lodash": "^4.17.11",
+    "lodash.clonedeep": "^4.5.0",
     "log-symbols": "^3.0.0",
     "make-dir": "^2.1.0",
     "netrc-parser": "^3.1.6",

--- a/package.json
+++ b/package.json
@@ -54,16 +54,19 @@
     "log-symbols": "^3.0.0",
     "make-dir": "^2.1.0",
     "netrc-parser": "^3.1.6",
-    "nimbu-client": "^1.0.4",
+    "nimbu-client": "^1.0.5",
     "node-fetch": "^2.2.0",
     "node-sass": "^4.9.3",
     "node-yaml": "^3.1.1",
+    "np": "^5.0.3",
     "os": "^0.1.1",
     "postcss-flexbugs-fixes": "^4.1.0",
     "postcss-loader": "^3.0.0",
+    "pretty-bytes": "^5.3.0",
     "promise": "^8.0.2",
     "react-dev-utils": "^9.0.1",
     "react-svg-core": "^3.0.3",
+    "request-progress": "^3.0.0",
     "rxjs": "^6.5.2",
     "sass-loader": "^7.1.0",
     "script-loader": "^0.7.2",
@@ -71,6 +74,7 @@
     "supports-color": "^6.1.0",
     "supports-hyperlinks": "^1.0.1",
     "through": "^2.3.8",
+    "tmp-promise": "^2.0.2",
     "tslib": "^1",
     "uglifyjs-webpack-plugin": "^2.0.1",
     "urlencode": "^1.1.0",
@@ -156,6 +160,9 @@
       },
       "mails": {
         "description": "manage your notification templates"
+      },
+      "channels": {
+        "description": "manage your channels"
       }
     }
   },

--- a/src/commands/channels/copy.ts
+++ b/src/commands/channels/copy.ts
@@ -8,7 +8,7 @@ import through from 'through'
 import inquirer from 'inquirer'
 import { Observable } from 'rxjs'
 
-export default class CopyChannels extends Command {
+export default class CopyChannelEntries extends Command {
   static description = 'copy channel configuration from one to another'
 
   static flags = {
@@ -26,7 +26,7 @@ export default class CopyChannels extends Command {
 
   async run() {
     const Listr = require('listr')
-    const { flags } = this.parse(CopyChannels)
+    const { flags } = this.parse(CopyChannelEntries)
 
     let fromChannel: string
     let toChannel: string
@@ -176,7 +176,7 @@ export default class CopyChannels extends Command {
       prompt({
         type: 'confirm',
         name: 'overwrite',
-        message: `channel ${chalk.bold(ctx.toChannel)} already exists. Overwrite config?`,
+        message: `channel ${chalk.bold(ctx.toChannel)} already exists. Update?`,
         default: false,
       })
         .then(answer => {

--- a/src/commands/channels/copy.ts
+++ b/src/commands/channels/copy.ts
@@ -70,7 +70,7 @@ export default class CopyChannels extends Command {
       },
       {
         title: upsertTitle,
-        enabled: ctx => ctx.channel !== undefined,
+        enabled: ctx => ctx.channel != null,
         task: (ctx, task) => this.copy(ctx, task),
       },
     ])
@@ -87,13 +87,13 @@ export default class CopyChannels extends Command {
 
   private async fetch(ctx: any) {
     let options: any = {}
-    if (ctx.fromSite !== undefined) {
+    if (ctx.fromSite != null) {
       options.site = ctx.fromSite
     }
     try {
       ctx.channel = await this.nimbu.get(`/channels/${ctx.fromChannel}`, options)
     } catch (error) {
-      if (error.body !== undefined && error.body.code === 101) {
+      if (error.body != null && error.body.code === 101) {
         throw new Error(`could not find channel ${chalk.bold(ctx.fromChannel)}`)
       } else {
         throw new Error(error.message)
@@ -103,7 +103,7 @@ export default class CopyChannels extends Command {
 
   private async copy(ctx: any, task: any) {
     let options: any = {}
-    if (ctx.toSite !== undefined) {
+    if (ctx.toSite != null) {
       options.site = ctx.toSite
     }
 
@@ -118,7 +118,7 @@ export default class CopyChannels extends Command {
       }
     }
 
-    if (targetChannel !== undefined) {
+    if (targetChannel != null) {
       return this.askOverwrite(ctx, task)
     } else {
       return this.create(ctx, task)
@@ -127,7 +127,7 @@ export default class CopyChannels extends Command {
 
   private async create(ctx: any, task: any) {
     let options: any = {}
-    if (ctx.toSite !== undefined) {
+    if (ctx.toSite != null) {
       options.site = ctx.toSite
     }
 
@@ -141,7 +141,7 @@ export default class CopyChannels extends Command {
 
   private async update(ctx: any, task: any) {
     let options: any = {}
-    if (ctx.toSite !== undefined) {
+    if (ctx.toSite != null) {
       options.site = ctx.toSite
     }
 

--- a/src/commands/channels/copy.ts
+++ b/src/commands/channels/copy.ts
@@ -176,7 +176,7 @@ export default class CopyChannels extends Command {
       prompt({
         type: 'confirm',
         name: 'overwrite',
-        message: `channel ${chalk.bold(ctx.toChannel)} already exists. Overwrite?`,
+        message: `channel ${chalk.bold(ctx.toChannel)} already exists. Overwrite config?`,
         default: false,
       })
         .then(answer => {

--- a/src/commands/channels/entries/copy.ts
+++ b/src/commands/channels/entries/copy.ts
@@ -1,0 +1,328 @@
+import Command from '../../../command'
+import Config from '../../../nimbu/config'
+import * as Nimbu from '../../../nimbu/types'
+import { download, generateRandom } from '../../../utils/files'
+
+import { flags } from '@oclif/command'
+import ux from 'cli-ux'
+import chalk from 'chalk'
+import { Observable } from 'rxjs'
+import fs from 'fs-extra'
+
+export default class CopyChannels extends Command {
+  static description = 'copy channel entries from one to another'
+
+  static flags = {
+    from: flags.string({
+      char: 'f',
+      description: 'slug of the source channel',
+      required: true,
+    }),
+    to: flags.string({
+      char: 't',
+      description: 'slug of the target channel',
+      required: true,
+    }),
+    query: flags.string({
+      char: 'q',
+      description: 'query params to apply to source channel',
+    }),
+    upsert: flags.string({
+      char: 'u',
+      description: 'name of parameter to use for matching existing documents',
+    }),
+    per_page: flags.string({
+      char: 'p',
+      description: 'number of entries to fetch per page',
+    }),
+  }
+
+  async run() {
+    const Listr = require('listr')
+    const { flags } = this.parse(CopyChannels)
+
+    let fromChannel: string
+    let toChannel: string
+    let fromSite: string | undefined
+    let toSite: string | undefined
+
+    let fromParts = flags.from.split('/')
+    if (fromParts.length > 1) {
+      fromSite = fromParts[0]
+      fromChannel = fromParts[1]
+    } else {
+      fromSite = Config.site
+      fromChannel = fromParts[0]
+    }
+    let toParts = flags.to.split('/')
+    if (toParts.length > 1) {
+      toSite = toParts[0]
+      toChannel = toParts[1]
+    } else {
+      toSite = Config.site
+      toChannel = toParts[0]
+    }
+
+    if (fromSite === undefined) {
+      ux.error('You need to specify the source site.')
+      return
+    }
+
+    if (toSite === undefined) {
+      ux.error('You need to specify the destination site.')
+      return
+    }
+
+    let fetchTitle = `Fetching channel information ${chalk.bold(fromChannel)} from site ${chalk.bold(fromSite)}`
+    let queryTitle = `Querying entries from channel ${chalk.bold(fromChannel)}`
+    let downloadTitle = `Downloading attachments from channel ${chalk.bold(fromChannel)}`
+    let createTitle = `Creating entries in channel ${chalk.bold(toChannel)} for site ${chalk.bold(toSite)}`
+
+    const tasks = new Listr([
+      {
+        title: fetchTitle,
+        task: ctx => this.fetchChannel(ctx),
+      },
+      {
+        title: queryTitle,
+        task: (ctx, task) => this.queryChannel(ctx, task),
+      },
+      {
+        title: downloadTitle,
+        task: (ctx, task) => this.downloadAttachments(ctx, task),
+      },
+      {
+        title: createTitle,
+        skip: ctx => ctx.entries.length === 0,
+        task: (ctx, task) => this.createEntries(ctx, task),
+      },
+    ])
+
+    tasks
+      .run({
+        fromChannel,
+        fromSite,
+        toChannel,
+        toSite,
+        query: flags.query,
+        per_page: flags.per_page,
+        upsert: flags.upsert,
+      })
+      .catch(error => {
+        ux.error(error)
+      })
+  }
+
+  private async fetchChannel(ctx: any) {
+    let options: any = {}
+    if (ctx.fromSite != null) {
+      options.site = ctx.fromSite
+    }
+    try {
+      ctx.channel = await this.nimbu.get(`/channels/${ctx.fromChannel}`, options)
+      ctx.fileFields = ctx.channel.customizations.filter(f => f.type === 'file')
+      ctx.galleryFields = ctx.channel.customizations.filter(f => f.type === 'gallery')
+      ctx.selectFields = ctx.channel.customizations.filter(f => f.type === 'select')
+      ctx.multiSelectFields = ctx.channel.customizations.filter(f => f.type === 'multi_select')
+    } catch (error) {
+      if (error.body != null && error.body.code === 101) {
+        throw new Error(`could not find channel ${chalk.bold(ctx.fromChannel)}`)
+      } else {
+        throw new Error(error.message)
+      }
+    }
+  }
+
+  private async queryChannel(ctx: any, task: any) {
+    let options: any = { fetchAll: true }
+    if (ctx.fromSite != null) {
+      options.site = ctx.fromSite
+    }
+
+    // first count the entries
+    let baseUrl = `/channels/${ctx.fromChannel}/entries`
+    let queryParts: string[] = []
+    let queryFromCtx: string | undefined = ctx.query
+    if (queryFromCtx != null && queryFromCtx.trim() !== '') {
+      queryParts.push(queryFromCtx.trim())
+    }
+    let perPageFromCtx: string | undefined = ctx.per_page
+    let perPage = 30
+    if (perPageFromCtx != null && parseInt(perPageFromCtx, 10) > 0) {
+      perPage = parseInt(perPageFromCtx, 10)
+      queryParts.push(`per_page=${perPage}`)
+    }
+    let query = queryParts.length > 0 ? `?${queryParts.join('&')}` : ''
+    let url = `${baseUrl}/count${query}`
+    let result = await this.nimbu.get<Nimbu.CountResult>(url, options)
+    ctx.count = result.count
+
+    let nbPages = 1
+    if (ctx.count > 0) {
+      nbPages = Math.floor(ctx.count / perPage) + 1
+    }
+    ctx.entries = []
+
+    return new Observable(observer => {
+      url = `${baseUrl}${query}`
+      observer.next(`Fetching entries (page ${1} / ${nbPages})`)
+
+      options.onNextPage = (next, last) => {
+        observer.next(`Fetching entries (page ${next} / ${last})`)
+      }
+
+      this.nimbu
+        .get<any>(url, options)
+        .then(function(results) {
+          task.title = `Got ${results.length} entries from ${chalk.bold(ctx.fromChannel)}`
+          ctx.entries = results
+          ctx.nbEntries = results.length
+        })
+        .then(() => observer.complete())
+        .catch(error => {
+          if (error.body != null && error.body.code === 101) {
+            throw new Error(`could not find channel ${chalk.bold(ctx.fromChannel)}`)
+          } else {
+            throw new Error(error.message)
+          }
+        })
+    })
+  }
+
+  private async downloadAttachments(ctx: any, task: any) {
+    return new Observable(observer => {
+      ;(async (observer, ctx) => {
+        let i = 1
+        ctx.files = {}
+
+        for (let entry of ctx.entries) {
+          for (let field of ctx.fileFields) {
+            let fileObject = entry[field.name]
+            if (fileObject != null) {
+              let cacheKey = this.fileCacheKey(entry, field)
+              await this.downloadFile(observer, i, ctx, fileObject, cacheKey, field.name)
+            }
+          }
+          for (let field of ctx.galleryFields) {
+            let galleryObject = entry[field.name]
+            if (galleryObject != null && galleryObject.images != null) {
+              for (let image of galleryObject.images) {
+                let fileObject = image.file
+                let cacheKey = this.galleryCacheKey(entry, field, image)
+                await this.downloadFile(observer, i, ctx, fileObject, cacheKey, field.name)
+              }
+            }
+          }
+          i++
+        }
+
+        observer.complete()
+      })(observer, ctx).catch(error => {
+        throw error
+      })
+    })
+  }
+
+  private async downloadFile(observer, i, ctx, fileObject, cacheKey, fieldName) {
+    let tmp = require('tmp-promise')
+    let prettyBytes = require('pretty-bytes')
+    let pathFinder = require('path')
+
+    if (fileObject != null && fileObject !== null && fileObject.url != null) {
+      let url = fileObject.url.replace('http://', 'https://') + '?' + generateRandom(6)
+      const { path, cleanup } = await tmp.file({ prefix: `${fieldName}-` })
+      let filename = pathFinder.basename(url)
+
+      try {
+        await download(url, path, (bytes, percentage) => {
+          observer.next(
+            `[${i}/${ctx.nbEntries}] Downloading ${fieldName} => "${filename}" (${percentage}% of ${prettyBytes(
+              bytes,
+            )})`,
+          )
+        })
+      } catch (error) {
+        observer.error(error)
+      }
+
+      ctx.files[cacheKey] = { path, cleanup }
+    }
+  }
+
+  private async createEntries(ctx: any, task: any) {
+    return new Observable(observer => {
+      ;(async (observer, ctx) => {
+        let i = 1
+        let nbEntries = ctx.entries.length
+
+        for (let entry of ctx.entries) {
+          for (let field of ctx.fileFields) {
+            let file = entry[field.name]
+            if (file != null) {
+              const key = this.fileCacheKey(entry, field)
+              if (ctx.files[key] != null) {
+                delete entry[field.name].url
+                entry[field.name].attachment = await fs.readFile(ctx.files[key].path, { encoding: 'base64' })
+              }
+            }
+          }
+
+          for (let field of ctx.galleryFields) {
+            let galleryObject = entry[field.name]
+            if (galleryObject != null && galleryObject.images != null) {
+              for (let image of galleryObject.images) {
+                const key = this.galleryCacheKey(entry, field, image)
+                delete image.id
+                if (ctx.files[key] != null) {
+                  delete image.file.url
+                  image.file.attachment = await fs.readFile(ctx.files[key].path, { encoding: 'base64' })
+                }
+              }
+            }
+          }
+
+          // flatten all select fields
+          for (let field of ctx.selectFields) {
+            if (entry[field.name] != null && entry[field.name].value != null) {
+              entry[field.name] = entry[field.name].value
+            }
+          }
+
+          for (let field of ctx.multiSelectFields) {
+            if (entry[field.name] != null && entry[field.name].values != null) {
+              entry[field.name] = entry[field.name].values
+            }
+          }
+
+          observer.next(`[${i}/${nbEntries}] creating entry "${chalk.bold(entry.title_field_value)}"`)
+
+          let options: any = {}
+          if (ctx.toSite != null) {
+            options.site = ctx.toSite
+          }
+          options.body = entry
+
+          try {
+            await this.nimbu.post(`/channels/${ctx.toChannel}/entries`, options)
+          } catch (error) {
+            observer.error(error)
+          }
+
+          i++
+        }
+
+        observer.complete()
+      })(observer, ctx).catch(error => {
+        throw error
+      })
+    })
+  }
+
+  private fileCacheKey(entry, field) {
+    return `${entry.id}-${field.name}`
+  }
+
+  private galleryCacheKey(entry, field, image) {
+    return `${entry.id}-${field.name}-${image.id}`
+  }
+}

--- a/src/commands/channels/entries/copy.ts
+++ b/src/commands/channels/entries/copy.ts
@@ -89,12 +89,13 @@ export default class CopyChannels extends Command {
       },
       {
         title: downloadTitle,
-        task: (ctx, task) => this.downloadAttachments(ctx, task),
+        skip: ctx => ctx.fileFields.length === 0 && ctx.galleryFields.length === 0,
+        task: ctx => this.downloadAttachments(ctx),
       },
       {
         title: createTitle,
         skip: ctx => ctx.entries.length === 0,
-        task: (ctx, task) => this.createEntries(ctx, task),
+        task: ctx => this.createEntries(ctx),
       },
     ])
 
@@ -143,12 +144,12 @@ export default class CopyChannels extends Command {
     let baseUrl = `/channels/${ctx.fromChannel}/entries`
     let queryParts: string[] = []
     let queryFromCtx: string | undefined = ctx.query
-    if (queryFromCtx != null && queryFromCtx.trim() !== '') {
+    if (queryFromCtx !== undefined && queryFromCtx.trim() !== '') {
       queryParts.push(queryFromCtx.trim())
     }
     let perPageFromCtx: string | undefined = ctx.per_page
     let perPage = 30
-    if (perPageFromCtx != null && parseInt(perPageFromCtx, 10) > 0) {
+    if (perPageFromCtx !== undefined && parseInt(perPageFromCtx, 10) > 0) {
       perPage = parseInt(perPageFromCtx, 10)
       queryParts.push(`per_page=${perPage}`)
     }
@@ -189,7 +190,7 @@ export default class CopyChannels extends Command {
     })
   }
 
-  private async downloadAttachments(ctx: any, task: any) {
+  private async downloadAttachments(ctx: any) {
     return new Observable(observer => {
       ;(async (observer, ctx) => {
         let i = 1
@@ -249,7 +250,7 @@ export default class CopyChannels extends Command {
     }
   }
 
-  private async createEntries(ctx: any, task: any) {
+  private async createEntries(ctx: any) {
     return new Observable(observer => {
       ;(async (observer, ctx) => {
         let i = 1

--- a/src/commands/channels/entries/copy.ts
+++ b/src/commands/channels/entries/copy.ts
@@ -117,9 +117,7 @@ export default class CopyChannels extends Command {
         per_page: flags.per_page,
         upsert: flags.upsert,
       })
-      .catch(error => {
-        //ux.error(error)
-      })
+      .catch(() => {})
   }
 
   private async fetchChannel(ctx: any) {

--- a/src/commands/customers/config/copy.ts
+++ b/src/commands/customers/config/copy.ts
@@ -1,0 +1,161 @@
+import Command from '../../../command'
+import Config from '../../../nimbu/config'
+
+import { flags } from '@oclif/command'
+import ux from 'cli-ux'
+import chalk from 'chalk'
+import through from 'through'
+import inquirer from 'inquirer'
+import { Observable } from 'rxjs'
+
+export default class CopyCustomerConfig extends Command {
+  static description = 'copy channel configuration from one to another'
+
+  static flags = {
+    from: flags.string({
+      char: 'f', // shorter flag version
+      description: 'subdomain of the source site',
+      default: Config.site,
+    }),
+    to: flags.string({
+      char: 't', // shorter flag version
+      description: 'subdomain of the destination site',
+      default: Config.site,
+    }),
+  }
+
+  async run() {
+    const Listr = require('listr')
+    const { flags } = this.parse(CopyCustomerConfig)
+
+    let fromSite = flags.from!
+    let toSite = flags.to!
+
+    if (fromSite === toSite) {
+      ux.error('The source site needs to differ from the destination.')
+      return
+    }
+
+    let fetchTitle = `Fetching customer customizations from site ${chalk.bold(fromSite)}`
+    let upsertTitle = `Copying customer customizations to site ${chalk.bold(toSite)}`
+
+    const tasks = new Listr([
+      {
+        title: fetchTitle,
+        task: ctx => this.fetch(ctx),
+      },
+      {
+        title: upsertTitle,
+        enabled: ctx => ctx.customizations != null,
+        task: (ctx, task) => this.copy(ctx, task),
+      },
+    ])
+
+    tasks
+      .run({
+        fromSite,
+        toSite,
+      })
+      .catch(() => {})
+  }
+
+  private async fetch(ctx: any) {
+    let options: any = {
+      site: ctx.fromSite,
+    }
+    try {
+      ctx.customizations = await this.nimbu.get(`/customers/customizations`, options)
+    } catch (error) {
+      throw new Error(error.message)
+    }
+  }
+
+  private async copy(ctx: any, task: any) {
+    let options: any = { site: ctx.toSite }
+    let targetCustomizations: any
+
+    // check if any target customizations exists
+    try {
+      targetCustomizations = await this.nimbu.get(`/customers/customizations`, options)
+    } catch (error) {
+      // if (error.body === undefined || error.body.code !== 101) {
+      throw new Error(error.message)
+      // }
+    }
+
+    if (targetCustomizations.length > 0) {
+      return this.askOverwrite(ctx, task)
+    } else {
+      return this.create(ctx, task)
+    }
+  }
+
+  private async create(ctx: any, task: any) {
+    let options: any = {
+      site: ctx.toSite,
+      body: ctx.customizations,
+    }
+
+    task.title = `Copying customizations to site ${chalk.bold(ctx.toSite)}`
+
+    return this.nimbu.post(`/customers/customizations`, options)
+  }
+
+  private async update(ctx: any, task: any) {
+    let options: any = {
+      site: ctx.toSite,
+      body: ctx.customizations,
+    }
+
+    task.title = `Updating customizations in site ${chalk.bold(ctx.toSite)}`
+
+    return this.nimbu.post(`/customers/customizations?replace=1`, options)
+  }
+
+  private askOverwrite(ctx: any, task: any) {
+    return new Observable(observer => {
+      let buffer = ''
+
+      const outputStream = through(data => {
+        if (/\u001b\[.*?(D|C)$/.test(data)) {
+          if (buffer.length > 0) {
+            observer.next(buffer)
+            buffer = ''
+          }
+          return
+        }
+
+        buffer += data
+      })
+
+      const prompt = inquirer.createPromptModule({
+        output: outputStream,
+      })
+
+      prompt({
+        type: 'confirm',
+        name: 'overwrite',
+        message: `Are you sure you want to overwrite the existing customizations?`,
+        default: false,
+      })
+        .then(answer => {
+          // Clear the output
+          observer.next()
+
+          if (answer.overwrite) {
+            return this.update(ctx, task)
+          } else {
+            task.skip(`Skipping update customer customizations ${ctx.toSite}`)
+          }
+        })
+        .then(() => {
+          observer.complete()
+        })
+        .catch(err => {
+          observer.error(err)
+        })
+
+      return outputStream
+    })
+  }
+}

--- a/src/commands/products/config/copy.ts
+++ b/src/commands/products/config/copy.ts
@@ -1,0 +1,161 @@
+import Command from '../../../command'
+import Config from '../../../nimbu/config'
+
+import { flags } from '@oclif/command'
+import ux from 'cli-ux'
+import chalk from 'chalk'
+import through from 'through'
+import inquirer from 'inquirer'
+import { Observable } from 'rxjs'
+
+export default class CopyProductsConfig extends Command {
+  static description = 'copy channel configuration from one to another'
+
+  static flags = {
+    from: flags.string({
+      char: 'f', // shorter flag version
+      description: 'subdomain of the source site',
+      default: Config.site,
+    }),
+    to: flags.string({
+      char: 't', // shorter flag version
+      description: 'subdomain of the destination site',
+      default: Config.site,
+    }),
+  }
+
+  async run() {
+    const Listr = require('listr')
+    const { flags } = this.parse(CopyProductsConfig)
+
+    let fromSite = flags.from!
+    let toSite = flags.to!
+
+    if (fromSite === toSite) {
+      ux.error('The source site needs to differ from the destination.')
+      return
+    }
+
+    let fetchTitle = `Fetching product customizations from site ${chalk.bold(fromSite)}`
+    let upsertTitle = `Copying product customizations to site ${chalk.bold(toSite)}`
+
+    const tasks = new Listr([
+      {
+        title: fetchTitle,
+        task: ctx => this.fetch(ctx),
+      },
+      {
+        title: upsertTitle,
+        enabled: ctx => ctx.customizations != null,
+        task: (ctx, task) => this.copy(ctx, task),
+      },
+    ])
+
+    tasks
+      .run({
+        fromSite,
+        toSite,
+      })
+      .catch(() => {})
+  }
+
+  private async fetch(ctx: any) {
+    let options: any = {
+      site: ctx.fromSite,
+    }
+    try {
+      ctx.customizations = await this.nimbu.get(`/products/customizations`, options)
+    } catch (error) {
+      throw new Error(error.message)
+    }
+  }
+
+  private async copy(ctx: any, task: any) {
+    let options: any = { site: ctx.toSite }
+    let targetCustomizations: any
+
+    // check if any target customizations exists
+    try {
+      targetCustomizations = await this.nimbu.get(`/products/customizations`, options)
+    } catch (error) {
+      // if (error.body === undefined || error.body.code !== 101) {
+      throw new Error(error.message)
+      // }
+    }
+
+    if (targetCustomizations.length > 0) {
+      return this.askOverwrite(ctx, task)
+    } else {
+      return this.create(ctx, task)
+    }
+  }
+
+  private async create(ctx: any, task: any) {
+    let options: any = {
+      site: ctx.toSite,
+      body: ctx.customizations,
+    }
+
+    task.title = `Copying customizations to site ${chalk.bold(ctx.toSite)}`
+
+    return this.nimbu.post(`/products/customizations`, options)
+  }
+
+  private async update(ctx: any, task: any) {
+    let options: any = {
+      site: ctx.toSite,
+      body: ctx.customizations,
+    }
+
+    task.title = `Updating customizations in site ${chalk.bold(ctx.toSite)}`
+
+    return this.nimbu.post(`/products/customizations?replace=1`, options)
+  }
+
+  private askOverwrite(ctx: any, task: any) {
+    return new Observable(observer => {
+      let buffer = ''
+
+      const outputStream = through(data => {
+        if (/\u001b\[.*?(D|C)$/.test(data)) {
+          if (buffer.length > 0) {
+            observer.next(buffer)
+            buffer = ''
+          }
+          return
+        }
+
+        buffer += data
+      })
+
+      const prompt = inquirer.createPromptModule({
+        output: outputStream,
+      })
+
+      prompt({
+        type: 'confirm',
+        name: 'overwrite',
+        message: `Are you sure you want to overwrite the existing customizations?`,
+        default: false,
+      })
+        .then(answer => {
+          // Clear the output
+          observer.next()
+
+          if (answer.overwrite) {
+            return this.update(ctx, task)
+          } else {
+            task.skip(`Skipping update product customizations ${ctx.toSite}`)
+          }
+        })
+        .then(() => {
+          observer.complete()
+        })
+        .catch(err => {
+          observer.error(err)
+        })
+
+      return outputStream
+    })
+  }
+}

--- a/src/nimbu/types.ts
+++ b/src/nimbu/types.ts
@@ -1,7 +1,5 @@
-export interface App {
-  name: string
-  key: string
-  url?: string
+export interface CountResult {
+  count: number
 }
 
 export interface AppFile {

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -1,4 +1,10 @@
+import { parse } from 'url'
+import http from 'https'
+import fs from 'fs-extra'
+import { basename } from 'path'
 import glob from 'glob'
+
+const TIMEOUT = 10000
 
 const promiseGlob = function(pattern: string, options: glob.IOptions = {}): Promise<string[]> {
   return new Promise((resolve, reject) => {
@@ -8,4 +14,49 @@ const promiseGlob = function(pattern: string, options: glob.IOptions = {}): Prom
 
 export async function findMatchingFiles(dir: string, pattern: string): Promise<string[]> {
   return promiseGlob(`${dir}/${pattern}`)
+}
+
+export function download(url, path, callback) {
+  return new Promise(function(resolve, reject) {
+    const uri = parse(url)
+    if (!path) {
+      path = basename(uri.path!)
+    }
+    const file = fs.createWriteStream(path)
+    const request = http.get(uri.href!).on('response', function(res) {
+      const len = parseInt(res.headers['content-length'], 10)
+      let bytes: number = 0
+      let percent: number = 0
+      res
+        .on('data', function(chunk) {
+          file.write(chunk)
+          bytes += chunk.length
+          percent = parseFloat(((bytes * 100.0) / len).toFixed(2))
+          if (callback !== undefined && callback instanceof Function) {
+            callback(bytes, percent)
+          }
+        })
+        .on('end', function() {
+          file.end()
+          resolve()
+        })
+        .on('error', function(err) {
+          reject(err)
+        })
+    })
+    request.setTimeout(TIMEOUT, function() {
+      request.abort()
+      reject(new Error(`request timeout after ${TIMEOUT / 1000.0}s`))
+    })
+  })
+}
+
+export function generateRandom(length) {
+  let result = ''
+  let characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+  let charactersLength = characters.length
+  for (let i = 0; i < length; i++) {
+    result += characters.charAt(Math.floor(Math.random() * charactersLength))
+  }
+  return result
 }

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -25,8 +25,8 @@ export function download(url, path, callback) {
     const file = fs.createWriteStream(path)
     const request = http.get(uri.href!).on('response', function(res) {
       const len = parseInt(res.headers['content-length'], 10)
-      let bytes: number = 0
-      let percent: number = 0
+      let bytes = 0
+      let percent = 0
       res
         .on('data', function(chunk) {
           file.write(chunk)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1203,6 +1203,18 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@sindresorhus/is@^0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
+  integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
+
+"@szmarczak/http-timer@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
+  integrity sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==
+  dependencies:
+    defer-to-connect "^1.0.1"
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
@@ -1383,6 +1395,11 @@
   version "12.6.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.8.tgz#e469b4bf9d1c9832aee4907ba8a051494357c12c"
   integrity sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==
+
+"@types/normalize-package-data@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
+  integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
 "@types/q@^1.5.1":
   version "1.5.2"
@@ -1931,6 +1948,11 @@ async-each@^1.0.1:
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
   integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
 
+async-exit-hook@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/async-exit-hook/-/async-exit-hook-2.0.1.tgz#8bd8b024b0ec9b1c01cccb9af9db29bd717dfaf3"
+  integrity sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==
+
 async-foreach@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/async-foreach/-/async-foreach-0.1.3.tgz#36121f845c0578172de419a97dbeb1d16ec34542"
@@ -2477,6 +2499,11 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
+builtins@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
+  integrity sha1-y5T662HIaWRR2zZTThQi+U8K7og=
+
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
@@ -2521,6 +2548,19 @@ cache-base@^1.0.1:
     to-object-path "^0.3.0"
     union-value "^1.0.0"
     unset-value "^1.0.0"
+
+cacheable-request@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-6.1.0.tgz#20ffb8bd162ba4be11e9567d823db651052ca912"
+  integrity sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==
+  dependencies:
+    clone-response "^1.0.2"
+    get-stream "^5.1.0"
+    http-cache-semantics "^4.0.0"
+    keyv "^3.0.0"
+    lowercase-keys "^2.0.0"
+    normalize-url "^4.1.0"
+    responselike "^1.0.2"
 
 caching-transform@^3.0.1:
   version "3.0.2"
@@ -2689,6 +2729,11 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+chardet@^0.4.0:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
+  integrity sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=
 
 chardet@^0.7.0:
   version "0.7.0"
@@ -2943,6 +2988,13 @@ clone-deep@^2.0.1:
     is-plain-object "^2.0.4"
     kind-of "^6.0.0"
     shallow-clone "^1.0.0"
+
+clone-response@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.2.tgz#d1dc973920314df67fbeb94223b4ee350239e96b"
+  integrity sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=
+  dependencies:
+    mimic-response "^1.0.0"
 
 clone@^1.0.2:
   version "1.0.4"
@@ -3231,7 +3283,7 @@ cosmiconfig@^4.0.0:
     parse-json "^4.0.0"
     require-from-string "^2.0.1"
 
-cosmiconfig@^5.0.5:
+cosmiconfig@^5.0.5, cosmiconfig@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
   integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
@@ -3522,6 +3574,13 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
+decompress-response@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
+  integrity sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=
+  dependencies:
+    mimic-response "^1.0.0"
+
 deep-eql@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
@@ -3561,6 +3620,11 @@ defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
+defer-to-connect@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.0.2.tgz#4bae758a314b034ae33902b5aac25a8dd6a8633e"
+  integrity sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw==
+
 define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
@@ -3590,7 +3654,7 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
-del@^4.0.0, del@^4.1.1:
+del@^4.0.0, del@^4.1.0, del@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/del/-/del-4.1.1.tgz#9e8f117222ea44a31ff3a156c049b99052a9f0b4"
   integrity sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==
@@ -3980,6 +4044,11 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+escape-string-regexp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
 eslint-config-airbnb-base@^13.1.0:
   version "13.2.0"
   resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz#f6ea81459ff4dec2dda200c35f1d8f7419d57943"
@@ -4235,6 +4304,15 @@ extend@~3.0.2:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
+external-editor@^2.0.4:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
+  integrity sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==
+  dependencies:
+    chardet "^0.4.0"
+    iconv-lite "^0.4.17"
+    tmp "^0.0.33"
+
 external-editor@^3.0.3:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
@@ -4440,6 +4518,14 @@ find-up@^2.0.0, find-up@^2.1.0:
   integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
   dependencies:
     locate-path "^2.0.0"
+
+find-up@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
+  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
+  dependencies:
+    locate-path "^5.0.0"
+    path-exists "^4.0.0"
 
 flat@^4.1.0:
   version "4.1.0"
@@ -4691,10 +4777,17 @@ get-stream@^3.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
   integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
 
-get-stream@^4.0.0:
+get-stream@^4.0.0, get-stream@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
   integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
+  dependencies:
+    pump "^3.0.0"
+
+get-stream@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.1.0.tgz#01203cdc92597f9b909067c3e656cc1f4d3c4dc9"
+  integrity sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
   dependencies:
     pump "^3.0.0"
 
@@ -4716,6 +4809,11 @@ github-slugger@^1.2.1:
   integrity sha512-SsZUjg/P03KPzQBt7OxJPasGw6NRO5uOgiZ5RGXVud5iSIZ0eNZeNp5rTwCxtavrRUa/A77j8mePVc5lEvk0KQ==
   dependencies:
     emoji-regex ">=6.0.0 <=6.1.1"
+
+github-url-from-git@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/github-url-from-git/-/github-url-from-git-1.5.0.tgz#f985fedcc0a9aa579dc88d7aff068d55cc6251a0"
+  integrity sha1-+YX+3MCpqledyI16/waNVcxiUaA=
 
 glob-parent@^3.1.0:
   version "3.1.0"
@@ -4844,6 +4942,23 @@ got@^6.7.1:
     unzip-response "^2.0.1"
     url-parse-lax "^1.0.0"
 
+got@^9.6.0:
+  version "9.6.0"
+  resolved "https://registry.yarnpkg.com/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
+  integrity sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==
+  dependencies:
+    "@sindresorhus/is" "^0.14.0"
+    "@szmarczak/http-timer" "^1.1.2"
+    cacheable-request "^6.0.0"
+    decompress-response "^3.3.0"
+    duplexer3 "^0.1.4"
+    get-stream "^4.1.0"
+    lowercase-keys "^1.0.1"
+    mimic-response "^1.0.1"
+    p-cancelable "^1.0.0"
+    to-readable-stream "^1.0.0"
+    url-parse-lax "^3.0.0"
+
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.0.tgz#8d8fdc73977cb04104721cb53666c1ca64cd328b"
@@ -4949,6 +5064,11 @@ has-values@^1.0.0:
     is-number "^3.0.0"
     kind-of "^4.0.0"
 
+has-yarn@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/has-yarn/-/has-yarn-2.1.0.tgz#137e11354a7b5bf11aa5cb649cf0c6f3ff2b2e77"
+  integrity sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==
+
 has@^1.0.1, has@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
@@ -4998,7 +5118,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hosted-git-info@^2.1.4:
+hosted-git-info@^2.1.4, hosted-git-info@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
   integrity sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==
@@ -5061,6 +5181,11 @@ htmlparser2@~3.3.0:
     domhandler "2.1"
     domutils "1.1"
     readable-stream "1.0"
+
+http-cache-semantics@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz#495704773277eeef6e43f9ab2c2c7d259dda25c5"
+  integrity sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==
 
 http-call@^5.1.2:
   version "5.2.4"
@@ -5162,7 +5287,7 @@ hyperlinker@^1.0.0:
   resolved "https://registry.yarnpkg.com/hyperlinker/-/hyperlinker-1.0.0.tgz#23dc9e38a206b208ee49bc2d6c8ef47027df0c0e"
   integrity sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.11:
+iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.11:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -5327,7 +5452,27 @@ inquirer@6.2.2:
     strip-ansi "^5.0.0"
     through "^2.3.6"
 
-inquirer@^6.2.2:
+inquirer@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
+  integrity sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.0.4"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rx-lite "^4.0.8"
+    rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
+inquirer@^6.2.1, inquirer@^6.2.2:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.5.0.tgz#2303317efc9a4ea7ec2e2df6f86569b734accf42"
   integrity sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==
@@ -5380,6 +5525,11 @@ ip-regex@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
   integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
+
+ip-regex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.1.0.tgz#5ad62f685a14edb421abebc2fff8db94df67b455"
+  integrity sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA==
 
 ip@^1.1.0, ip@^1.1.5:
   version "1.1.5"
@@ -5652,6 +5802,13 @@ is-root@2.0.0:
   resolved "https://registry.yarnpkg.com/is-root/-/is-root-2.0.0.tgz#838d1e82318144e5a6f77819d90207645acc7019"
   integrity sha512-F/pJIk8QD6OX5DNhRB7hWamLsUilmkDGho48KbgZ6xg/lmAZXHxzXQ91jzB3yRSw5kdQGGGc4yz8HYhTYIMWPg==
 
+is-scoped@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-scoped/-/is-scoped-2.1.0.tgz#fef0713772658bdf5bee418608267ddae6d3566d"
+  integrity sha512-Cv4OpPTHAK9kHYzkzCrof3VJh7H/PrG2MBUMvvJebaaUMbqhm0YAtXnvh0I3Hnj2tMZWwrRROWLSgfJrKqWmlQ==
+  dependencies:
+    scoped-regex "^2.0.0"
+
 is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
@@ -5673,6 +5830,13 @@ is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
+is-url-superb@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-url-superb/-/is-url-superb-3.0.0.tgz#b9a1da878a1ac73659047d1e6f4ef22c209d3e25"
+  integrity sha512-3faQP+wHCGDQT1qReM5zCPx2mxoal6DzbzquFlCYJLWyy4WPTved33ea2xFbX37z4NoriEwZGIYhFtx8RUB5wQ==
+  dependencies:
+    url-regex "^5.0.0"
 
 is-url@^1.2.1:
   version "1.2.4"
@@ -5730,6 +5894,11 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
+
+issue-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/issue-regex/-/issue-regex-2.0.0.tgz#bb1802490394f8083c7a6787247cbf975638ef5d"
+  integrity sha512-flaQ/45dMqCYSMzBQI/h3bcto6T70uN7kjNnI8n3gQU6no5p+QcnMWBNXkraED0YvbUymxKaqdvgPa09RZQM5A==
 
 istanbul-lib-coverage@^2.0.3, istanbul-lib-coverage@^2.0.5:
   version "2.0.5"
@@ -5831,6 +6000,11 @@ jsesc@~0.5.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
   integrity sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
 
+json-buffer@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
+  integrity sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=
+
 json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
@@ -5902,6 +6076,13 @@ junk@3.0.0:
   resolved "https://registry.yarnpkg.com/junk/-/junk-3.0.0.tgz#f0454fb7ef9bcf67e2c32214dde22c08cadfc629"
   integrity sha512-8oLnegfzPD/7V2oLI+kacn941P7IEYKDdjbwBJQWqWFdoZduX+YOJIrZEEYehd9aSk00J2m+l3fppxAmAc4sXQ==
 
+keyv@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"
+  integrity sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==
+  dependencies:
+    json-buffer "3.0.0"
+
 killable@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"
@@ -5951,6 +6132,20 @@ lcid@^2.0.0:
   integrity sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==
   dependencies:
     invert-kv "^2.0.0"
+
+lines-and-columns@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
+  integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
+
+listr-input@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/listr-input/-/listr-input-0.1.3.tgz#0c313967b6d179ebe964a81e9363ce2a5a39d25c"
+  integrity sha512-dvjSD1MrWGXxxPixpMQlSBmkyqhJrPxGo30un25k/vlvFOWZj70AauU+YkEh7CA8vmpkE6Wde37DJDmqYqF39g==
+  dependencies:
+    inquirer "^3.3.0"
+    rxjs "^5.5.2"
+    through "^2.3.8"
 
 listr-silent-renderer@^1.1.1:
   version "1.1.1"
@@ -6087,6 +6282,13 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
+locate-path@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
+  integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
+  dependencies:
+    p-locate "^4.1.0"
+
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -6162,12 +6364,17 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
+lodash.zip@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
+  integrity sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=
+
 lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.3, lodash@^4.17.5, lodash@~4.17.10:
   version "4.17.14"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
   integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
 
-lodash@^4.17.10, lodash@^4.17.13, lodash@^4.17.14:
+lodash@^4.17.10, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.3.0:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -6227,10 +6434,15 @@ lower-case@^1.1.1:
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
   integrity sha1-miyr0bno4K6ZOkv31YdcOcQujqw=
 
-lowercase-keys@^1.0.0:
+lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
   integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
+
+lowercase-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
+  integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
 lru-cache@^4.0.1:
   version "4.1.5"
@@ -6339,7 +6551,7 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
-mem@^4.0.0:
+mem@^4.0.0, mem@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-4.3.0.tgz#461af497bc4ae09608cdb2e60eefb69bff744178"
   integrity sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==
@@ -6476,10 +6688,15 @@ mimic-fn@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
-mimic-fn@^2.0.0:
+mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+mimic-response@^1.0.0, mimic-response@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
+  integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
@@ -6733,10 +6950,10 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-nimbu-client@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/nimbu-client/-/nimbu-client-1.0.4.tgz#839dfb712374857cd5b89f5d3627002f88acb041"
-  integrity sha512-NuiJUcmPqCYK+9KbejmEQ18COJnX5+Bzus5awlSIprd02X8nd8R0PspC+mARIvdxqrkY+jgx4smUfgngbVxHEQ==
+nimbu-client@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/nimbu-client/-/nimbu-client-1.0.5.tgz#9b0355211a1a139094b5425e9fa3fd876b5e7819"
+  integrity sha512-gvGWvyh7wHHxHzebbT0goXI8SvlT87hxws250E1yG2zX+y4k2QcM3zwX9+EBEAzo2zPmklEinVbErlkNlbTxTw==
   dependencies:
     is-retry-allowed "^1.1.0"
     semver "^6.2.0"
@@ -6927,10 +7144,67 @@ normalize-range@^0.1.2:
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
   integrity sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=
 
+normalize-url@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.3.0.tgz#9c49e10fc1876aeb76dba88bf1b2b5d9fa57b2ee"
+  integrity sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==
+
+np@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/np/-/np-5.0.3.tgz#69e160850d7c89a644b3917e2728eee50de88609"
+  integrity sha512-j8tK6bqKANlZry+chd4LotCBSOuQpCnmSUVk5KOA1AfGu/GmIFE6lPwrkhEX3VkOFsZLW2C3+UmWZYVnMyyCbw==
+  dependencies:
+    "@samverschueren/stream-to-observable" "^0.3.0"
+    any-observable "^0.3.0"
+    async-exit-hook "^2.0.1"
+    chalk "^2.3.0"
+    cosmiconfig "^5.2.1"
+    del "^4.1.0"
+    escape-string-regexp "^2.0.0"
+    execa "^1.0.0"
+    github-url-from-git "^1.5.0"
+    has-yarn "^2.1.0"
+    hosted-git-info "^2.7.1"
+    inquirer "^6.2.1"
+    is-installed-globally "^0.1.0"
+    is-scoped "^2.1.0"
+    issue-regex "^2.0.0"
+    listr "^0.14.3"
+    listr-input "^0.1.3"
+    log-symbols "^3.0.0"
+    meow "^5.0.0"
+    npm-name "^5.0.1"
+    onetime "^5.1.0"
+    open "^6.1.0"
+    ow "^0.12.0"
+    p-memoize "^3.1.0"
+    p-timeout "^3.1.0"
+    pkg-dir "^4.1.0"
+    read-pkg-up "^5.0.0"
+    rxjs "^6.3.3"
+    semver "^6.0.0"
+    split "^1.0.0"
+    symbol-observable "^1.2.0"
+    terminal-link "^1.2.0"
+    update-notifier "^2.1.0"
+
 npm-bundled@^1.0.1:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.6.tgz#e7ba9aadcef962bb61248f91721cd932b3fe6bdd"
   integrity sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==
+
+npm-name@^5.0.1:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/npm-name/-/npm-name-5.5.0.tgz#3a73adbcb0488a41a44ff820ed51dcc32c72bd09"
+  integrity sha512-l7/uyVfEi2e3ho+ovaJZC0xlbwzXNUz3RxkxpfcnLuoGKAuYoo9YoJ/uy18PsTD8IziugGHks4t/mGmBJEZ4Qg==
+  dependencies:
+    got "^9.6.0"
+    is-scoped "^2.1.0"
+    is-url-superb "^3.0.0"
+    lodash.zip "^4.2.0"
+    registry-auth-token "^4.0.0"
+    registry-url "^5.1.0"
+    validate-npm-package-name "^3.0.0"
 
 npm-packlist@^1.1.6:
   version "1.4.4"
@@ -7126,6 +7400,20 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+onetime@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.0.tgz#fff0f3c91617fe62bb50189636e99ac8a6df7be5"
+  integrity sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==
+  dependencies:
+    mimic-fn "^2.1.0"
+
+open@^6.1.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-6.4.0.tgz#5c13e96d0dc894686164f18965ecfe889ecfc8a9"
+  integrity sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==
+  dependencies:
+    is-wsl "^1.1.0"
+
 opn@5.4.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.4.0.tgz#cb545e7aab78562beb11aa3bfabc7042e1761035"
@@ -7211,6 +7499,16 @@ osenv@0, osenv@^0.1.4:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
 
+ow@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/ow/-/ow-0.12.0.tgz#ce3b53a81af78171a21478bd684bd9862b152b35"
+  integrity sha512-GWAoq5RiK3HpMbwvM/aszyYYm7UvZzNfx5QPDbCXd52lROiDVBn6x6M06DhsL/Y8BTl42djQAPWhu6adaWwZyQ==
+
+p-cancelable@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-1.1.0.tgz#d078d15a3af409220c886f1d9a0ca2e441ab26cc"
+  integrity sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==
+
 p-defer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
@@ -7240,6 +7538,13 @@ p-limit@^2.0.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
+  integrity sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -7254,10 +7559,25 @@ p-locate@^3.0.0:
   dependencies:
     p-limit "^2.0.0"
 
+p-locate@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
+  integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
+  dependencies:
+    p-limit "^2.2.0"
+
 p-map@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
   integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
+
+p-memoize@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-memoize/-/p-memoize-3.1.0.tgz#ac7587983c9e530139f969ca7b41ef40e93659aa"
+  integrity sha512-e5tIvrsr7ydUUnxb534iQWtXxWgk/86IsH+H+nV4FHouIggBt4coXboKBt26o4lTu7JbEnGSeXdEsYR8BhAHFA==
+  dependencies:
+    mem "^4.3.0"
+    mimic-fn "^2.1.0"
 
 p-retry@^3.0.1:
   version "3.0.1"
@@ -7265,6 +7585,13 @@ p-retry@^3.0.1:
   integrity sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==
   dependencies:
     retry "^0.12.0"
+
+p-timeout@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.1.0.tgz#198c1f503bb973e9b9727177a276c80afd6851f3"
+  integrity sha512-C27DYI+tCroT8J8cTEyySGydl2B7FlxrGNF5/wmMbl1V+jeehUCzEE/BVgzRebdm2K3ZitKOKx8YbdFumDyYmw==
+  dependencies:
+    p-finally "^1.0.0"
 
 p-try@^1.0.0:
   version "1.0.0"
@@ -7344,6 +7671,16 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
+parse-json@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.0.0.tgz#73e5114c986d143efa3712d4ea24db9a4266f60f"
+  integrity sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
+    lines-and-columns "^1.1.6"
+
 parse-ms@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-2.1.0.tgz#348565a753d4391fa524029956b172cb7753097d"
@@ -7388,6 +7725,11 @@ path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
   integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
+
+path-exists@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
+  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -7506,6 +7848,13 @@ pkg-dir@^3.0.0:
   integrity sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
   dependencies:
     find-up "^3.0.0"
+
+pkg-dir@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
+  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
+  dependencies:
+    find-up "^4.0.0"
 
 pkg-up@2.0.0:
   version "2.0.0"
@@ -7632,6 +7981,16 @@ prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
+
+prepend-http@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
+  integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
+
+pretty-bytes@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.3.0.tgz#f2849e27db79fb4d6cfe24764fc4134f165989f2"
+  integrity sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg==
 
 pretty-error@^2.0.2:
   version "2.1.1"
@@ -7865,7 +8224,7 @@ raw-loader@~0.5.1:
   resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-0.5.1.tgz#0c3d0beaed8a01c966d9787bf778281252a979aa"
   integrity sha1-DD0L6u2KAclm2Xh793goElKpeao=
 
-rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
+rc@^1.0.1, rc@^1.1.6, rc@^1.2.7, rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -7956,6 +8315,14 @@ read-pkg-up@^4.0.0:
     find-up "^3.0.0"
     read-pkg "^3.0.0"
 
+read-pkg-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-5.0.0.tgz#b6a6741cb144ed3610554f40162aa07a6db621b8"
+  integrity sha512-XBQjqOBtTzyol2CpsQOw8LHV0XbDZVG7xMMjmXAJomlVY03WOBRmYgDJETlvcg0H63AJvPRwT7GFi5rvOzUOKg==
+  dependencies:
+    find-up "^3.0.0"
+    read-pkg "^5.0.0"
+
 read-pkg@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
@@ -7982,6 +8349,16 @@ read-pkg@^3.0.0:
     load-json-file "^4.0.0"
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
+
+read-pkg@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.2.0.tgz#7bf295438ca5a33e56cd30e053b34ee7250c93cc"
+  integrity sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==
+  dependencies:
+    "@types/normalize-package-data" "^2.4.0"
+    normalize-package-data "^2.5.0"
+    parse-json "^5.0.0"
+    type-fest "^0.6.0"
 
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.6"
@@ -8130,12 +8507,27 @@ registry-auth-token@^3.0.1:
     rc "^1.1.6"
     safe-buffer "^5.0.1"
 
+registry-auth-token@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-4.0.0.tgz#30e55961eec77379da551ea5c4cf43cbf03522be"
+  integrity sha512-lpQkHxd9UL6tb3k/aHAVfnVtn+Bcs9ob5InuFLLEDqSqeq+AljB8GZW9xY0x7F+xYwEcjKe07nyoxzEYz6yvkw==
+  dependencies:
+    rc "^1.2.8"
+    safe-buffer "^5.0.1"
+
 registry-url@^3.0.3:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-3.1.0.tgz#3d4ef870f73dde1d77f0cf9a381432444e174942"
   integrity sha1-PU74cPc93h138M+aOBQyRE4XSUI=
   dependencies:
     rc "^1.0.1"
+
+registry-url@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-5.1.0.tgz#e98334b50d5434b81136b44ec638d9c2009c5009"
+  integrity sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==
+  dependencies:
+    rc "^1.2.8"
 
 regjsgen@^0.2.0:
   version "0.2.0"
@@ -8205,6 +8597,13 @@ repeating@^2.0.0:
   integrity sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=
   dependencies:
     is-finite "^1.0.0"
+
+request-progress@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/request-progress/-/request-progress-3.0.0.tgz#4ca754081c7fec63f505e4faa825aa06cd669dbe"
+  integrity sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=
+  dependencies:
+    throttleit "^1.0.0"
 
 request@^2.87.0, request@^2.88.0:
   version "2.88.0"
@@ -8291,6 +8690,13 @@ resolve@^1.10.0, resolve@^1.11.0, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.8.1
   dependencies:
     path-parse "^1.0.6"
 
+responselike@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/responselike/-/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"
+  integrity sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=
+  dependencies:
+    lowercase-keys "^1.0.0"
+
 restore-cursor@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
@@ -8337,6 +8743,25 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   integrity sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=
   dependencies:
     aproba "^1.1.1"
+
+rx-lite-aggregates@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
+  integrity sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=
+  dependencies:
+    rx-lite "*"
+
+rx-lite@*, rx-lite@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
+  integrity sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=
+
+rxjs@^5.5.2:
+  version "5.5.12"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.12.tgz#6fa61b8a77c3d793dbaf270bee2f43f652d741cc"
+  integrity sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==
+  dependencies:
+    symbol-observable "1.0.1"
 
 rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.2:
   version "6.5.2"
@@ -8410,6 +8835,11 @@ schema-utils@^1.0.0:
     ajv "^6.1.0"
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
+
+scoped-regex@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/scoped-regex/-/scoped-regex-2.1.0.tgz#7b9be845d81fd9d21d1ec97c61a0b7cf86d2015f"
+  integrity sha512-g3WxHrqSWCZHGHlSrF51VXFdjImhwvH8ZO/pryFH56Qi0cDsZfylQa/t0jCzVQFNbNvM00HfHjkDPEuarKDSWQ==
 
 script-loader@^0.7.2:
   version "0.7.2"
@@ -8789,6 +9219,13 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
+split@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
+  integrity sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==
+  dependencies:
+    through "2"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -9071,12 +9508,17 @@ svgo@^1.2.2:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
+symbol-observable@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
+  integrity sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=
+
 symbol-observable@^0.2.2:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-0.2.4.tgz#95a83db26186d6af7e7a18dbd9760a2f86d08f40"
   integrity sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=
 
-symbol-observable@^1.0.4, symbol-observable@^1.1.0:
+symbol-observable@^1.0.4, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
@@ -9147,6 +9589,14 @@ term-size@^1.2.0:
   dependencies:
     execa "^0.7.0"
 
+terminal-link@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/terminal-link/-/terminal-link-1.3.0.tgz#3e9a308289e13340053aaf40e8f1a06d1335646e"
+  integrity sha512-nFaWG/gs3brGi3opgWU2+dyFGbQ7tueSRYOBOD8URdDXCbAGqDEZzuskCc+okCClYcJFDPwn8e2mbv4FqAnWFA==
+  dependencies:
+    ansi-escapes "^3.2.0"
+    supports-hyperlinks "^1.0.1"
+
 terser-webpack-plugin@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.3.0.tgz#69aa22426299f4b5b3775cbed8cb2c5d419aa1d4"
@@ -9187,6 +9637,11 @@ text-table@0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
+throttleit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-1.0.0.tgz#9e785836daf46743145a5984b6268d828528ac6c"
+  integrity sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=
+
 through2@^2.0.0:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
@@ -9195,7 +9650,7 @@ through2@^2.0.0:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
-through@^2.3.6, through@^2.3.8:
+through@2, through@^2.3.6, through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -9221,6 +9676,25 @@ timers-browserify@^2.0.4:
   integrity sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==
   dependencies:
     setimmediate "^1.0.4"
+
+tlds@^1.203.0:
+  version "1.203.1"
+  resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.203.1.tgz#4dc9b02f53de3315bc98b80665e13de3edfc1dfc"
+  integrity sha512-7MUlYyGJ6rSitEZ3r1Q1QNV8uSIzapS8SmmhSusBuIc7uIxPPwsKllEP0GRp1NS6Ik6F+fRZvnjDWm3ecv2hDw==
+
+tmp-promise@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-2.0.2.tgz#ee605edb10f100954be5dd8b9dbe1bfd56194202"
+  integrity sha512-zl71nFWjPKW2KXs+73gEk8RmqvtAeXPxhWDkTUoa3MSMkjq3I+9OeknjF178MQoMYsdqL730hfzvNfEkePxq9Q==
+  dependencies:
+    tmp "0.1.0"
+
+tmp@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
+  integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==
+  dependencies:
+    rimraf "^2.6.3"
 
 tmp@^0.0.33:
   version "0.0.33"
@@ -9250,6 +9724,11 @@ to-object-path@^0.3.0:
   integrity sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=
   dependencies:
     kind-of "^3.0.2"
+
+to-readable-stream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/to-readable-stream/-/to-readable-stream-1.0.0.tgz#ce0aa0c2f3df6adf852efb404a783e77c0475771"
+  integrity sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==
 
 to-regex-range@^2.1.0:
   version "2.1.1"
@@ -9451,6 +9930,11 @@ type-fest@^0.3.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1"
   integrity sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==
 
+type-fest@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
+  integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
+
 type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
@@ -9608,7 +10092,7 @@ upath@^1.1.1:
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.2.tgz#3db658600edaeeccbe6db5e684d67ee8c2acd068"
   integrity sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==
 
-update-notifier@^2.5.0:
+update-notifier@^2.1.0, update-notifier@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.5.0.tgz#d0744593e13f161e406acb1d9408b72cad08aff6"
   integrity sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==
@@ -9648,6 +10132,13 @@ url-parse-lax@^1.0.0:
   dependencies:
     prepend-http "^1.0.1"
 
+url-parse-lax@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz#16b5cafc07dbe3676c1b1999177823d6503acb0c"
+  integrity sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=
+  dependencies:
+    prepend-http "^2.0.0"
+
 url-parse@^1.4.3:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
@@ -9655,6 +10146,14 @@ url-parse@^1.4.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
+
+url-regex@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/url-regex/-/url-regex-5.0.0.tgz#8f5456ab83d898d18b2f91753a702649b873273a"
+  integrity sha512-O08GjTiAFNsSlrUWfqF1jH0H1W3m35ZyadHrGv5krdnmPPoxP27oDTqux/579PtaroiSGm5yma6KT1mHFH6Y/g==
+  dependencies:
+    ip-regex "^4.1.0"
+    tlds "^1.203.0"
 
 url@^0.11.0:
   version "0.11.0"
@@ -9735,6 +10234,13 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+validate-npm-package-name@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz#5fa912d81eb7d0c74afc140de7317f0ca7df437e"
+  integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
+  dependencies:
+    builtins "^1.0.3"
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Adds new command `nimbu channels:entries:copy` to copy entries from one channel to another. 

Following command flags can be used:
- `from` (required): the source channel, formatted as `channel_slug` or `site_subdomain/channel_slug`
- `to` (required): the target channel, formatted as `channel_slug` or `site_subdomain/channel_slug`
- `query`: optional query parameters to limit the source entries 

Adds new commands `nimbu products:config:copy` and `nimbu customers:config:copy` to copy products / customer custom fields from one site to another. 